### PR TITLE
feat(product-repository): adicionar AutoMapper e repositório de produtos

### DIFF
--- a/MechShopping.ProductAPI/Config/MappingConfig.cs
+++ b/MechShopping.ProductAPI/Config/MappingConfig.cs
@@ -1,0 +1,19 @@
+﻿using AutoMapper;
+using MechShopping.ProductAPI.Data.ValueObjects;
+using MechShopping.ProductAPI.Model;
+
+namespace MechShopping.ProductAPI.Config
+{
+    public class MappingConfig
+    {
+        public static MapperConfiguration RegisterMaps()
+        {
+            var mappingConfig = new MapperConfiguration(config =>
+            {
+                config.CreateMap<ProductVO, Product>();
+                config.CreateMap<Product, Product>();
+            });
+            return mappingConfig;
+        }
+    }
+}

--- a/MechShopping.ProductAPI/Data/ValueObjects/ProductVO.cs
+++ b/MechShopping.ProductAPI/Data/ValueObjects/ProductVO.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace MechShopping.ProductAPI.Data.ValueObjects
+{
+    public class ProductVO
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+        public string? Description { get; set; }
+        public string? CategoryName { get; set; }
+        public string? ImageURL { get; set; }
+    }
+}

--- a/MechShopping.ProductAPI/Program.cs
+++ b/MechShopping.ProductAPI/Program.cs
@@ -1,5 +1,8 @@
 
+using AutoMapper;
+using MechShopping.ProductAPI.Config;
 using MechShopping.ProductAPI.Model.Context;
+using MechShopping.ProductAPI.Repository;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.Extensions.Options;
@@ -13,13 +16,22 @@ namespace MechShopping.ProductAPI
             var builder = WebApplication.CreateBuilder(args);
             var connection = builder.Configuration.GetConnectionString("SqlServerConnection");
 
+            IMapper mapper = MappingConfig.RegisterMaps().CreateMapper();
+            builder.Services.AddSingleton(mapper);
+            builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());
+
+            builder.Services.AddScoped<IProductRepository, ProductRepository>();
+
             builder.Services.AddDbContext<SQLServerContext>(options => options.UseSqlServer(connection));
             // Add services to the container.
 
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+            builder.Services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo { Title = "MechShopping.ProductAPI", Version = "v1" });
+            });
 
             var app = builder.Build();
 

--- a/MechShopping.ProductAPI/Repository/IProductRepository.cs
+++ b/MechShopping.ProductAPI/Repository/IProductRepository.cs
@@ -1,0 +1,13 @@
+﻿using MechShopping.ProductAPI.Data.ValueObjects;
+
+namespace MechShopping.ProductAPI.Repository
+{
+    public interface IProductRepository
+    {
+        Task<IEnumerable<ProductVO>> FindAll();
+        Task<ProductVO> FindById(long id);
+        Task<ProductVO> Create(ProductVO vo);
+        Task<ProductVO> Update(ProductVO vo);
+        Task<bool> Delete(long id);
+    }
+}

--- a/MechShopping.ProductAPI/Repository/ProductRepository.cs
+++ b/MechShopping.ProductAPI/Repository/ProductRepository.cs
@@ -1,0 +1,58 @@
+﻿using AutoMapper;
+using MechShopping.ProductAPI.Data.ValueObjects;
+using MechShopping.ProductAPI.Model;
+using MechShopping.ProductAPI.Model.Context;
+using Microsoft.EntityFrameworkCore;
+
+namespace MechShopping.ProductAPI.Repository
+{
+    public class ProductRepository: IProductRepository
+    {
+        private readonly SQLServerContext _context;
+        private readonly IMapper _mapper;
+        public ProductRepository(SQLServerContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+        public async Task<IEnumerable<ProductVO>> FindAll()
+        {
+            List<Product> products = await _context.Products.ToListAsync();
+            return _mapper.Map<List<ProductVO>>(products);
+        }
+        public async Task<ProductVO> FindById(long id)
+        {
+            Product product = await _context.Products.Where(p => p.Id == id).FirstOrDefaultAsync();
+            return _mapper.Map<ProductVO>(product);
+        }
+        public async Task<ProductVO> Create(ProductVO vo)
+        {
+            Product product = _mapper.Map<Product>(vo);
+            _context.Products.Add(product);
+            await _context.SaveChangesAsync();
+            return _mapper.Map<ProductVO>(product);
+        }
+        public async Task<ProductVO> Update(ProductVO vo)
+        {
+            Product product = _mapper.Map<Product>(vo);
+            _context.Products.Update(product);
+            await _context.SaveChangesAsync();
+            return _mapper.Map<ProductVO>(product);
+        }
+        public async Task<bool> Delete(long id)
+        {
+            try
+            {
+                Product product = await _context.Products.Where(p => p.Id == id).FirstOrDefaultAsync();
+                if (product == null) return false;
+                _context.Products.Remove(product);
+                await _context.SaveChangesAsync();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adicionada a biblioteca AutoMapper para mapeamento entre objetos.
- Criada a classe MappingConfig para configurar os mapeamentos.
- Adicionada a interface IProductRepository para operações CRUD.
- Implementada a classe ProductRepository com suporte ao AutoMapper.
- Adicionada a classe ProductVO para representar os dados do produto.
- Configurada a injeção de dependência de ProductRepository no Program.cs.
- Alterada a configuração do Swagger para incluir título e versão da API.
- Configurado o uso do SQL Server no Program.cs com SQLServerContext.
- Atualizado o pipeline de desenvolvimento com novas dependências.